### PR TITLE
Bugfix for numpy parser

### DIFF
--- a/Hall_B/AIDAPT/aidapt_toolkit/data_parsers/aidapt_numpy_reader_v0.py
+++ b/Hall_B/AIDAPT/aidapt_toolkit/data_parsers/aidapt_numpy_reader_v0.py
@@ -62,6 +62,9 @@ class AIDAPTNumpyReaderV0(JDSTDataParser):
         if isinstance(self.config['filepaths'], str):
             self.config['filepaths'] = [self.config['filepaths']]
 
+        if isinstance(self.config['filepaths'], Path):
+            self.config['filepaths'] = [self.config['filepaths']]
+
     def get_info(self):
         """ Prints the docstring for the AIDAPTNumpyReaderV0 module"""
         print(inspect.getdoc(self))

--- a/Hall_B/AIDAPT/tests/test_aidapt_numpy_reader_v0.py
+++ b/Hall_B/AIDAPT/tests/test_aidapt_numpy_reader_v0.py
@@ -58,11 +58,14 @@ class TestNumpyReader:
 
         data_file = tmp_path.joinpath("temp_data.npy")
 
-        parser = self.base_init(config = {"filenames": data_file})
+        parser = self.base_init(config = {"filepaths": data_file})
 
-        parsed_data = parser.load_data()
+
+        print([f for f in tmp_path.walk()])
+
         np.save(data_file, data)
 
-        parser
+        parsed_data = parser.load_data()
+        assert np.allclose(parsed_data, data)
 
 


### PR DESCRIPTION
Parser can now read in a file when given a Pathlib object. This worked before with a list of Pathlib objects (because it was iterable), but didn't work when "filepaths" was a single path.